### PR TITLE
close lid: acpid enable

### DIFF
--- a/_posts/2014-04-28-making-suspend-on-lid-close-work-with-arch-linux-on-the-hp-chromebook-11.md
+++ b/_posts/2014-04-28-making-suspend-on-lid-close-work-with-arch-linux-on-the-hp-chromebook-11.md
@@ -66,4 +66,8 @@ And there you go. For this to work straight away you'll need to restart the acpi
 $ systemctl restart acpid
 ```
 
-And that's it. Now when you close the lid, you should see that the lights on the back turn off, so you can tell it has suspended.
+And that's it. Now when you close the lid, you should see that the lights on the back turn off, so you can tell it has suspended. To make this permanent you'll need to enable acpid on boot:
+
+```
+$ systemctl enable acpid
+```


### PR DESCRIPTION
Maybe it's just me (and even I should know better), but I was caught out without acpid enabled and ran down my battery pretty badly when i thought it was suspended. The backlight goes off in my configuration on lid close anyway (after a delay) and I had taken that to be a suspend, but it is just the backlight.

I'm not sure if this is the right way to handle these suggestions, on the ordinary blog I'd just post a comment, but things are perilously close to source code here.

Feel free to reject if you want to reflect these in a new post or something, or if you just want to ignore them. I could do a writeup on my own blag.
