### PR TITLE
added trailing slash to redirect_from url

### DIFF
--- a/_posts/2014-03-17-using-jekyll-redirect-from-with-github-pages.md
+++ b/_posts/2014-03-17-using-jekyll-redirect-from-with-github-pages.md
@@ -36,7 +36,7 @@ To use the plugin you have to do a couple of things
 
   ``` yaml
   redirect_from:
-   - "/post/some-old-slug"
+   - "/post/some-old-slug/"
   ```
 
 And that's it.


### PR DESCRIPTION
i tried this without the slash, but it downloaded a file instead of redirecting... adding the trailing slash made it work